### PR TITLE
Allow optionally specify 'readonly' in metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
                 "evermonkey.readonlyInMeta": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Show and allow readonly setting in metadata."
+                    "description": "Always show readonly attribute in metadata."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -220,6 +220,11 @@
                     "type": "boolean",
                     "default": "true",
                     "description": "Enable readonly notes feature."
+                },
+                "evermonkey.readonlyInMeta": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Show and allow readonly setting in metadata."
                 }
             }
         }

--- a/src/everapi.ts
+++ b/src/everapi.ts
@@ -5,12 +5,7 @@ import * as vscode from "vscode";
 const config = vscode.workspace.getConfiguration("evermonkey");
 const RECENT_NOTE_COUNT = config.recentNotesCount || 10;
 const MAX_NOTE_COUNT = config.maxNoteCount || 50;
-let attributes = {};
-if (config.noteReadonly) {
-  attributes = {
-    contentClass: "michalyao.vscode.evermonkey"
-  }
-} 
+export const CONTENT_CLASS = "michalyao.vscode.evermonkey"
 
 
 export class EvernoteClient {
@@ -68,7 +63,11 @@ export class EvernoteClient {
     return this.noteStore.getResource(guid, true, false, true, false);
   }
 
-  updateNoteContent(guid, title, content, tagNames, notebookGuid) {
+  updateNoteContent(guid, title, content, tagNames, notebookGuid, readonly) {
+    let attributes = {contentClass: null};
+    if (readonly) {
+      attributes.contentClass = CONTENT_CLASS;
+    }
     return this.noteStore.updateNote({
       guid,
       title,
@@ -79,7 +78,11 @@ export class EvernoteClient {
     });
   }
 
-  updateNoteResources(guid, title, content, tagNames, notebookGuid, resources) {
+  updateNoteResources(guid, title, content, tagNames, notebookGuid, resources, readonly) {
+    let attributes = {contentClass: null};
+    if (readonly) {
+      attributes.contentClass = CONTENT_CLASS;
+    }
     return this.noteStore.updateNote({
       guid,
       title,
@@ -98,7 +101,11 @@ export class EvernoteClient {
     });
   }
 
-  createNote(title, notebookGuid, content, tagNames, resources) {
+  createNote(title, notebookGuid, content, tagNames, resources, readonly) {
+    let attributes = {contentClass: null};
+    if (readonly) {
+      attributes.contentClass = CONTENT_CLASS;
+    }
     return this.noteStore.createNote({
       title,
       notebookGuid,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,16 +72,17 @@ function exactMetadata(text) {
 }
 
 function genMetaHeader(title, tags, notebook, readonly) {
+  let showReadonly : boolean = (config.readonlyInMeta || readonly != config.noteReadonly);
   const metaHeaderTemplate = `\
 ---
 title: %s
 tags: %s
 notebook: %s\
-${config.readonlyInMeta ? "\nreadonly: %s" : ""}
+${showReadonly ? "\nreadonly: %s" : ""}
 ---
 
 `;
-  if (config.readonlyInMeta) {
+  if (showReadonly) {
     return util.format(metaHeaderTemplate, title, tags.join(","), notebook, String(readonly));
   } else {
     return util.format(metaHeaderTemplate, title, tags.join(","), notebook);
@@ -465,7 +466,7 @@ async function newNote() {
     const editor = await vscode.window.showTextDocument(doc);
     let startPos = new vscode.Position(1, 0);
     editor.edit(edit => {
-      let metaHeader = genMetaHeader("", [], "", String(config.noteReadonly));
+      let metaHeader = genMetaHeader("", [], "", config.noteReadonly);
       edit.insert(startPos, metaHeader);
     });
     // start at the title.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,9 +11,7 @@ import {
 } from "./myutil";
 import fs from "./file";
 import * as evernote from "evernote";
-import {
-  EvernoteClient
-} from "./everapi";
+import * as everapi from "./everapi"
 
 const config = vscode.workspace.getConfiguration("evermonkey");
 
@@ -22,15 +20,6 @@ const ATTACHMENT_SOURCE_LOCAL = 0;
 const ATTACHMENT_SOURCE_SERVER = 1;
 const TIP_BACK = "back...";
 const METADATA_PATTERN = /^---[ \t]*\n((?:[ \t]*[^ \t:]+[ \t]*:[^\n]*\n)+)---[ \t]*\n/;
-
-const METADATA_HEADER = `\
----
-title: %s
-tags: %s
-notebook: %s
----
-
-`;
 
 // notesMap -- [notebookguid:[notes]].
 let notebooks, notesMap, selectedNotebook;
@@ -62,6 +51,18 @@ function exactMetadata(text) {
         let tagStr = metadata["tags"];
         metadata["tags"] = tagStr.split(",").map(value => value.trim());
       }
+      if (typeof metadata["readonly"] !== "undefined") {
+        if (metadata["readonly"] == "true") {
+          metadata["readonly"] = true;
+        } else if (metadata["readonly"] == "false") {
+          metadata["readonly"] = false;
+        } else {
+          vscode.window.showWarningMessage("Illegal 'readonly' metadata");
+          metadata["readonly"] = config.noteReadonly;
+        }
+      } else {
+        metadata["readonly"] = config.noteReadonly;
+      }
     }
   }
   return {
@@ -70,8 +71,21 @@ function exactMetadata(text) {
   };
 }
 
-function genMetaHeader(title, tags, notebook) {
-  return util.format(METADATA_HEADER, title, tags.join(","), notebook);
+function genMetaHeader(title, tags, notebook, readonly) {
+  const metaHeaderTemplate = `\
+---
+title: %s
+tags: %s
+notebook: %s\
+${config.readonlyInMeta ? "\nreadonly: %s" : ""}
+---
+
+`;
+  if (config.readonlyInMeta) {
+    return util.format(metaHeaderTemplate, title, tags.join(","), notebook, String(readonly));
+  } else {
+    return util.format(metaHeaderTemplate, title, tags.join(","), notebook);
+  }
 }
 
 // nav to one Note
@@ -108,7 +122,7 @@ async function syncAccount() {
     // TODO: configuration update event should be awared, so that a token can be reconfigured.
     const config = vscode.workspace.getConfiguration("evermonkey");
     await vscode.window.setStatusBarMessage("Synchronizing your account...", 1000);
-    client = new EvernoteClient(config.token, config.noteStoreUrl);
+    client = new everapi.EvernoteClient(config.token, config.noteStoreUrl);
     const tags = await client.listTags();
     tags.forEach(tag => tagCache[tag.guid] = tag.name);
     notebooks = await client.listNotebooks();
@@ -357,8 +371,9 @@ async function updateNoteResources(meta, content, noteGuid, resources) {
     let tagNames = meta["tags"];
     let title = meta["title"];
     let notebook = meta["notebook"];
+    let readonly = meta["readonly"];
     const notebookGuid = await getNotebookGuid(notebook);
-    return client.updateNoteResources(noteGuid, title, content, tagNames, notebookGuid, resources || void 0);
+    return client.updateNoteResources(noteGuid, title, content, tagNames, notebookGuid, resources || void 0, readonly);
 
   } catch (err) {
     wrapError(err);
@@ -370,8 +385,9 @@ async function updateNoteContent(meta, content, noteGuid) {
     let tagNames = meta["tags"];
     let title = meta["title"];
     let notebook = meta["notebook"];
+    let readonly = meta["readonly"];
     const notebookGuid = await getNotebookGuid(notebook);
-    return client.updateNoteContent(noteGuid, title, content, tagNames, notebookGuid);
+    return client.updateNoteContent(noteGuid, title, content, tagNames, notebookGuid, readonly);
 
   } catch (err) {
     wrapError(err);
@@ -407,8 +423,9 @@ async function createNote(meta, content, resources) {
     let tagNames = meta["tags"];
     let title = meta["title"];
     let notebook = meta["notebook"];
+    let readonly = meta["readonly"];
     const notebookGuid = await getNotebookGuid(notebook);
-    return client.createNote(title, notebookGuid, content, tagNames, resources);
+    return client.createNote(title, notebookGuid, content, tagNames, resources, readonly);
   } catch (err) {
     wrapError(err);
   }
@@ -448,7 +465,7 @@ async function newNote() {
     const editor = await vscode.window.showTextDocument(doc);
     let startPos = new vscode.Position(1, 0);
     editor.edit(edit => {
-      let metaHeader = util.format(METADATA_HEADER, "", "", "");
+      let metaHeader = genMetaHeader("", [], "", String(config.noteReadonly));
       edit.insert(startPos, metaHeader);
     });
     // start at the title.
@@ -608,7 +625,8 @@ async function cacheAndOpenNote(note, doc, content) {
       let mdContent = converter.toMd(content);
 
       let metaHeader = genMetaHeader(note.title, tags,
-        notebooks.find(notebook => notebook.guid === note.notebookGuid).name);
+        notebooks.find(notebook => notebook.guid === note.notebookGuid).name,
+        note.attributes.contentClass === everapi.CONTENT_CLASS);
       edit.insert(startPos, metaHeader + mdContent);
     });
   } catch (err) {


### PR DESCRIPTION
You can specify `readonly` to `true` or `false` in metadata.

When opening an existing note, by default, the `readonly` metadata is only shown when the readonly attribute is not consistent with current workspace setting `evermonkey.noteReadonly`.

Optionally, you can make `readonly` metadata always shown by setting `evermonkey.readonlyInMeta` to `true`.